### PR TITLE
Redirect unity Debug logs, and only open log handle once

### DIFF
--- a/Logger.cs
+++ b/Logger.cs
@@ -9,33 +9,27 @@ namespace FuckYouLogShit
         private static string LogFilePath    => $"{Core.ModDirectory}/../cleaned_output_log.txt";
         private static string ModLogFilePath => $"{Core.ModDirectory}/{Core.ModName}.log";
 
+        public static StreamWriter writer;
         public static void InitDebugFile()
         {
-            using (var writer = new StreamWriter(LogFilePath, false))
-            {
-                writer.WriteLine($"{DateTime.Now} Cleaned Log");
-                writer.WriteLine(new string(c: '-', count: 80));
-                writer.WriteLine(VersionInfo.GetFormattedInfo());
-            }
+            writer = new StreamWriter(LogFilePath, false);
+            writer.AutoFlush = true;
+            writer.WriteLine($"{DateTime.Now} Cleaned Log");
+            writer.WriteLine(new string(c: '-', count: 80));
+            writer.WriteLine(VersionInfo.GetFormattedInfo());
         }
 
         public static void Error(Exception ex)
         {
-            using (var writer = new StreamWriter(ModLogFilePath, true))
-            {
-                writer.WriteLine($"Message: {ex.Message}");
-                writer.WriteLine($"StackTrace: {ex.StackTrace}");
-                writer.WriteLine($"Date: {DateTime.Now}");
-                writer.WriteLine(new string(c: '-', count: 80));
-            }
+            writer.WriteLine($"Message: {ex.Message}");
+            writer.WriteLine($"StackTrace: {ex.StackTrace}");
+            writer.WriteLine($"Date: {DateTime.Now}");
+            writer.WriteLine(new string(c: '-', count: 80));
         }
 
         public static void Debug(String line)
         {
-            using (var writer = new StreamWriter(LogFilePath, true))
-            {
-                writer.WriteLine($"{DateTime.Now.ToString("s")} - {line}");
-            }
+            writer.WriteLine($"{DateTime.Now.ToString("s")} - {line}");
         }
     }
 }


### PR DESCRIPTION
Just a general idea.

This should for the most part entirely take over output_log.txt and send everything to FYLS.

It also includes the speedup from not opening a new stream for each logline.


Since FYLS gives the ability to filter logs, and this would prevent data from being written to output_log, it's recommended to add a second uncleaned log which can be reviewed in case some important data was filtered out.