### PR TITLE
Speed up log prefix matching

### DIFF
--- a/BT-FYLS.sln
+++ b/BT-FYLS.sln
@@ -1,5 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FYLS", "FYLS.csproj", "{EAB3F72E-BC74-4966-BAAA-97B1E5695091}"
 EndProject
 Global
@@ -12,5 +13,10 @@ Global
 		{EAB3F72E-BC74-4966-BAAA-97B1E5695091}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EAB3F72E-BC74-4966-BAAA-97B1E5695091}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EAB3F72E-BC74-4966-BAAA-97B1E5695091}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.DotNetNamingPolicy = $1
+		$1.DirectoryNamespaceAssociation = PrefixedHierarchical
 	EndGlobalSection
 EndGlobal

--- a/FYLS.csproj
+++ b/FYLS.csproj
@@ -32,28 +32,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=1.2.0.1, Culture=neutral, PublicKeyToken=null">
-      <HintPath>../../../Library/Application Support/Steam/steamapps/common/BATTLETECH/BattleTech.app/Contents/Resources/Mods/ModTek/0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>../../../Library/Application Support/Steam/steamapps/common/BATTLETECH/BattleTech.app/Contents/Resources/Data/Managed/Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>../../../Library/Application Support/Steam/steamapps/common/BATTLETECH/BattleTech.app/Contents/Resources/Data/Managed/Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>../../../Library/Application Support/Steam/steamapps/common/BATTLETECH/BattleTech.app/Contents/Resources/Data/Managed/UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="Core.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -63,6 +41,23 @@
     <Content Include="LICENSE" />
     <Content Include="mod.json" />
     <Content Include="README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="0Harmony">
+      <HintPath>..\..\..\Library\Application Support\Steam\steamapps\common\BATTLETECH\BattleTech.app\Contents\Resources\Mods\ModTek\0Harmony.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\..\Library\Application Support\Steam\steamapps\common\BATTLETECH\BattleTech.app\Contents\Resources\Data\Managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\Library\Application Support\Steam\steamapps\common\BATTLETECH\BattleTech.app\Contents\Resources\Mods\ModTek\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\..\Library\Application Support\Steam\steamapps\common\BATTLETECH\BattleTech.app\Contents\Resources\Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\..\..\Library\Application Support\Steam\steamapps\common\BATTLETECH\BattleTech.app\Contents\Resources\Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/mod.json
+++ b/mod.json
@@ -2,7 +2,7 @@
   "Name": "FYLS",
   "Enabled": true,
 
-  "Version": "1.3.0",
+  "Version": "1.4.0",
 
   "Author": "janxious",
   "Website": "https://github.com/janxious/BT-FYLS",


### PR DESCRIPTION
__ISSUE:__
_Performance_ - Filtering by prefix performance issues - Fixes #2

__DESCRIPTION:__
RT (and possibly other modpacks) are shipping with [large](https://github.com/BattletechModders/RogueTech/blob/72fdc89dbbddffd96b8d46099cd7c9a538bc073f/FYLS/mod.json#L18-L140) (121 currently)
log prefix filtering settings. The original method for filtering was not
intended for that size of prefixes (it worked fine with 2-10 certainly).
Regex is a better easy solution to filtering and may be good enough to
never need replacement or enhancement.

*Note: I haven't compiled this so there are probably some syntax errors.*

__STEPS TO TEST:__
Install new dll. Measure performance. @m22spencer seems likely to have
the ability to do this easily, but it should be noticeably less laggy.

__REFERENCES:__
0. [Discord Conversation about performance issue](https://discordapp.com/channels/565106671693856778/565134819894231040/740849129168830477)

__CHANGELIST:__
modified:   Core.cs